### PR TITLE
feat(client): add camera capture and display functionality

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -20,11 +20,110 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>WebRTC Client</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    .video-container video {
+      width: 100%;
+      max-width: 100%;
+      background-color: #000;
+    }
+    .stats-display {
+      font-family: monospace;
+      font-size: 0.9rem;
+    }
+  </style>
 </head>
 <body>
   <div class="container py-4">
-    <h1 class="text-center">Hello WebRTC</h1>
+    <h1 class="text-center mb-4">WebRTC Client</h1>
+
+    <!-- Server URL and Connection Controls -->
+    <div class="card mb-3">
+      <div class="card-body">
+        <div class="row g-3 align-items-center">
+          <div class="col-md-6">
+            <label for="serverUrl" class="form-label">Server URL</label>
+            <input type="text" class="form-control" id="serverUrl"
+                   placeholder="ws://localhost:8080/offer">
+          </div>
+          <div class="col-md-3">
+            <label for="resolution" class="form-label">Resolution</label>
+            <select class="form-select" id="resolution">
+              <option value="1920x1080">1920x1080 (Full HD)</option>
+              <option value="1280x720">1280x720 (HD)</option>
+              <option value="640x480" selected>640x480 (VGA)</option>
+              <option value="320x240">320x240 (QVGA)</option>
+            </select>
+          </div>
+          <div class="col-md-3 d-flex gap-2 align-items-end">
+            <button id="connectBtn" class="btn btn-primary flex-fill">Connect</button>
+            <button id="disconnectBtn" class="btn btn-secondary flex-fill" disabled>Disconnect</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Local Video -->
+    <div class="card mb-3">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Local Camera</span>
+        <button class="btn btn-sm btn-outline-secondary" type="button"
+                data-bs-toggle="collapse" data-bs-target="#localVideoCollapse"
+                aria-expanded="true" aria-controls="localVideoCollapse">
+          Toggle
+        </button>
+      </div>
+      <div class="collapse show" id="localVideoCollapse">
+        <div class="card-body video-container">
+          <video id="localVideo" autoplay playsinline muted></video>
+        </div>
+      </div>
+    </div>
+
+    <!-- Remote Video -->
+    <div class="card mb-3">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Remote Video (Server Processed)</span>
+        <button class="btn btn-sm btn-outline-secondary" type="button"
+                data-bs-toggle="collapse" data-bs-target="#remoteVideoCollapse"
+                aria-expanded="true" aria-controls="remoteVideoCollapse">
+          Toggle
+        </button>
+      </div>
+      <div class="collapse show" id="remoteVideoCollapse">
+        <div class="card-body video-container">
+          <video id="remoteVideo" autoplay playsinline></video>
+          <p class="text-muted mt-2 mb-0">No remote video available yet.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Server Response Text -->
+    <div class="card mb-3">
+      <div class="card-header">Server Response</div>
+      <div class="card-body">
+        <pre id="serverResponse" class="mb-0 text-muted">No response yet.</pre>
+      </div>
+    </div>
+
+    <!-- Statistics -->
+    <div class="card mb-3">
+      <div class="card-header">Statistics</div>
+      <div class="card-body stats-display">
+        <div class="row">
+          <div class="col-md-6">
+            <p class="mb-1">Frame Rate: <span id="statsFps">--</span> fps</p>
+            <p class="mb-1">Resolution: <span id="statsResolution">--</span></p>
+          </div>
+          <div class="col-md-6">
+            <p class="mb-1">Round Trip Time: <span id="statsRtt">--</span> ms</p>
+            <p class="mb-1">Bitrate: <span id="statsBitrate">--</span> kbps</p>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="src/main.js"></script>
 </body>
 </html>

--- a/client/src/camera.js
+++ b/client/src/camera.js
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 iwatake2222
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Camera capture module.
+ */
+
+/**
+ * Camera manager class for handling camera capture.
+ */
+export class CameraManager {
+  /**
+   * Creates a new CameraManager instance.
+   */
+  constructor() {
+    /** @type {MediaStream|null} */
+    this.stream = null;
+    /** @type {HTMLVideoElement|null} */
+    this.videoElement = null;
+    /** @type {boolean} */
+    this.isPlaying = true;
+  }
+
+  /**
+   * Starts camera capture and attaches to video element.
+   * @param {HTMLVideoElement} videoElement - The video element to display.
+   * @param {MediaStreamConstraints} [constraints] - Optional media constraints.
+   * @return {Promise<MediaStream>} The camera media stream.
+   */
+  async start(videoElement, constraints = {video: true, audio: false}) {
+    this.videoElement = videoElement;
+    this.stream = await navigator.mediaDevices.getUserMedia(constraints);
+    this.videoElement.srcObject = this.stream;
+    this.isPlaying = true;
+    return this.stream;
+  }
+
+  /**
+   * Stops camera capture and releases resources.
+   */
+  stop() {
+    if (this.stream) {
+      this.stream.getTracks().forEach((track) => track.stop());
+      this.stream = null;
+    }
+    if (this.videoElement) {
+      this.videoElement.srcObject = null;
+    }
+    this.isPlaying = false;
+  }
+
+  /**
+   * Pauses video playback (used when collapsed).
+   */
+  pause() {
+    if (this.videoElement && this.isPlaying) {
+      this.videoElement.pause();
+      this.isPlaying = false;
+    }
+  }
+
+  /**
+   * Resumes video playback (used when expanded).
+   */
+  resume() {
+    if (this.videoElement && !this.isPlaying) {
+      this.videoElement.play();
+      this.isPlaying = true;
+    }
+  }
+
+  /**
+   * Gets the current media stream.
+   * @return {MediaStream|null} The current media stream.
+   */
+  getStream() {
+    return this.stream;
+  }
+
+  /**
+   * Gets video track settings.
+   * @return {{width: number, height: number, frameRate: number}|null}
+   */
+  getVideoSettings() {
+    if (!this.stream) {
+      return null;
+    }
+    const videoTrack = this.stream.getVideoTracks()[0];
+    if (!videoTrack) {
+      return null;
+    }
+    const settings = videoTrack.getSettings();
+    return {
+      width: settings.width || 0,
+      height: settings.height || 0,
+      frameRate: settings.frameRate || 0,
+    };
+  }
+}

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -16,9 +16,123 @@
  */
 
 /**
- * @fileoverview Main entry point.
+ * @fileoverview Main entry point for WebRTC client.
  */
 
-import {greet} from './app.js';
+import {CameraManager} from './camera.js';
+import {StatsManager} from './stats.js';
 
-console.log(greet('WebRTC'));
+/** @type {CameraManager} */
+const cameraManager = new CameraManager();
+
+/** @type {StatsManager} */
+let statsManager;
+
+/**
+ * Initializes the application.
+ */
+async function init() {
+  const localVideo = /** @type {HTMLVideoElement} */ (
+    document.getElementById('localVideo')
+  );
+  const remoteVideo = /** @type {HTMLVideoElement} */ (
+    document.getElementById('remoteVideo')
+  );
+  const serverUrlInput = /** @type {HTMLInputElement} */ (
+    document.getElementById('serverUrl')
+  );
+  const resolutionSelect = /** @type {HTMLSelectElement} */ (
+    document.getElementById('resolution')
+  );
+  const connectBtn = /** @type {HTMLButtonElement} */ (
+    document.getElementById('connectBtn')
+  );
+  const disconnectBtn = /** @type {HTMLButtonElement} */ (
+    document.getElementById('disconnectBtn')
+  );
+  const serverResponse = document.getElementById('serverResponse');
+
+  statsManager = new StatsManager({
+    fps: document.getElementById('statsFps'),
+    resolution: document.getElementById('statsResolution'),
+    rtt: document.getElementById('statsRtt'),
+    bitrate: document.getElementById('statsBitrate'),
+  });
+
+  setupCollapseHandlers(localVideo, remoteVideo);
+
+  connectBtn.addEventListener('click', async () => {
+    try {
+      const constraints = buildConstraints(resolutionSelect.value);
+      await cameraManager.start(localVideo, constraints);
+      statsManager.startLocalStatsCollection(cameraManager);
+      connectBtn.disabled = true;
+      disconnectBtn.disabled = false;
+      resolutionSelect.disabled = true;
+      console.log('Camera started, URL:', serverUrlInput.value);
+    } catch (error) {
+      console.error('Failed to start camera:', error);
+      if (serverResponse) {
+        serverResponse.textContent = `Error: ${error.message}`;
+      }
+    }
+  });
+
+  disconnectBtn.addEventListener('click', () => {
+    cameraManager.stop();
+    statsManager.stopCollection();
+    statsManager.reset();
+    connectBtn.disabled = false;
+    disconnectBtn.disabled = true;
+    resolutionSelect.disabled = false;
+    console.log('Camera stopped');
+  });
+}
+
+/**
+ * Builds media constraints from resolution string.
+ * @param {string} resolution - Resolution string (e.g., "1280x720").
+ * @return {MediaStreamConstraints} The media constraints object.
+ */
+function buildConstraints(resolution) {
+  const [width, height] = resolution.split('x').map(Number);
+  return {
+    video: {
+      width: {ideal: width},
+      height: {ideal: height},
+    },
+    audio: false,
+  };
+}
+
+/**
+ * Sets up collapse event handlers for video containers.
+ * @param {HTMLVideoElement} localVideo - Local video element.
+ * @param {HTMLVideoElement} remoteVideo - Remote video element.
+ */
+function setupCollapseHandlers(localVideo, remoteVideo) {
+  const localCollapse = document.getElementById('localVideoCollapse');
+  const remoteCollapse = document.getElementById('remoteVideoCollapse');
+
+  if (localCollapse) {
+    localCollapse.addEventListener('hidden.bs.collapse', () => {
+      cameraManager.pause();
+    });
+    localCollapse.addEventListener('shown.bs.collapse', () => {
+      cameraManager.resume();
+    });
+  }
+
+  if (remoteCollapse) {
+    remoteCollapse.addEventListener('hidden.bs.collapse', () => {
+      remoteVideo.pause();
+    });
+    remoteCollapse.addEventListener('shown.bs.collapse', () => {
+      if (remoteVideo.srcObject) {
+        remoteVideo.play();
+      }
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/client/src/stats.js
+++ b/client/src/stats.js
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2026 iwatake2222
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Statistics display module.
+ */
+
+/**
+ * Statistics manager class for displaying video/connection stats.
+ */
+export class StatsManager {
+  /**
+   * Creates a new StatsManager instance.
+   * @param {Object} elements - DOM elements for displaying stats.
+   * @param {HTMLElement} elements.fps - Element for FPS display.
+   * @param {HTMLElement} elements.resolution - Element for resolution display.
+   * @param {HTMLElement} elements.rtt - Element for RTT display.
+   * @param {HTMLElement} elements.bitrate - Element for bitrate display.
+   */
+  constructor(elements) {
+    this.elements = elements;
+    /** @type {number|null} */
+    this.intervalId = null;
+    /** @type {number} */
+    this.lastBytes = 0;
+    /** @type {number} */
+    this.lastTimestamp = 0;
+  }
+
+  /**
+   * Updates the statistics display.
+   * @param {Object} stats - Statistics data.
+   * @param {number} [stats.fps] - Frame rate.
+   * @param {number} [stats.width] - Video width.
+   * @param {number} [stats.height] - Video height.
+   * @param {number} [stats.rtt] - Round trip time in ms.
+   * @param {number} [stats.bitrate] - Bitrate in kbps.
+   */
+  update(stats) {
+    if (stats.fps !== undefined && this.elements.fps) {
+      this.elements.fps.textContent = stats.fps.toFixed(1);
+    }
+    if (stats.width !== undefined && stats.height !== undefined &&
+        this.elements.resolution) {
+      this.elements.resolution.textContent = `${stats.width}x${stats.height}`;
+    }
+    if (stats.rtt !== undefined && this.elements.rtt) {
+      this.elements.rtt.textContent = stats.rtt.toFixed(1);
+    }
+    if (stats.bitrate !== undefined && this.elements.bitrate) {
+      this.elements.bitrate.textContent = stats.bitrate.toFixed(1);
+    }
+  }
+
+  /**
+   * Resets all statistics to default values.
+   */
+  reset() {
+    if (this.elements.fps) {
+      this.elements.fps.textContent = '--';
+    }
+    if (this.elements.resolution) {
+      this.elements.resolution.textContent = '--';
+    }
+    if (this.elements.rtt) {
+      this.elements.rtt.textContent = '--';
+    }
+    if (this.elements.bitrate) {
+      this.elements.bitrate.textContent = '--';
+    }
+    this.lastBytes = 0;
+    this.lastTimestamp = 0;
+  }
+
+  /**
+   * Starts periodic stats collection from camera manager.
+   * @param {Object} cameraManager - Camera manager instance.
+   * @param {number} [intervalMs=1000] - Update interval in milliseconds.
+   */
+  startLocalStatsCollection(cameraManager, intervalMs = 1000) {
+    this.stopCollection();
+    this.intervalId = setInterval(() => {
+      const settings = cameraManager.getVideoSettings();
+      if (settings) {
+        this.update({
+          fps: settings.frameRate,
+          width: settings.width,
+          height: settings.height,
+        });
+      }
+    }, intervalMs);
+  }
+
+  /**
+   * Stops periodic stats collection.
+   */
+  stopCollection() {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  /**
+   * Calculates bitrate from byte counts.
+   * @param {number} currentBytes - Current total bytes.
+   * @param {number} currentTimestamp - Current timestamp in ms.
+   * @return {number} Bitrate in kbps.
+   */
+  calculateBitrate(currentBytes, currentTimestamp) {
+    if (this.lastTimestamp === 0) {
+      this.lastBytes = currentBytes;
+      this.lastTimestamp = currentTimestamp;
+      return 0;
+    }
+    const timeDiff = (currentTimestamp - this.lastTimestamp) / 1000;
+    const byteDiff = currentBytes - this.lastBytes;
+    this.lastBytes = currentBytes;
+    this.lastTimestamp = currentTimestamp;
+    if (timeDiff <= 0) {
+      return 0;
+    }
+    return (byteDiff * 8) / timeDiff / 1000;
+  }
+}

--- a/client/tests/camera.test.js
+++ b/client/tests/camera.test.js
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2026 iwatake2222
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {CameraManager} from '../src/camera.js';
+
+describe('CameraManager', () => {
+  let cameraManager;
+  let mockVideoElement;
+  let mockStream;
+  let mockTrack;
+
+  beforeEach(() => {
+    cameraManager = new CameraManager();
+
+    mockTrack = {
+      stop: vi.fn(),
+      getSettings: vi.fn(() => ({
+        width: 1280,
+        height: 720,
+        frameRate: 30,
+      })),
+    };
+
+    mockStream = {
+      getTracks: vi.fn(() => [mockTrack]),
+      getVideoTracks: vi.fn(() => [mockTrack]),
+    };
+
+    mockVideoElement = {
+      srcObject: null,
+      pause: vi.fn(),
+      play: vi.fn(),
+    };
+
+    global.navigator = {
+      mediaDevices: {
+        getUserMedia: vi.fn(() => Promise.resolve(mockStream)),
+      },
+    };
+  });
+
+  describe('constructor', () => {
+    it('should initialize with null stream and video element', () => {
+      expect(cameraManager.stream).toBeNull();
+      expect(cameraManager.videoElement).toBeNull();
+      expect(cameraManager.isPlaying).toBe(true);
+    });
+  });
+
+  describe('start', () => {
+    it('should start camera and attach stream to video element', async () => {
+      const result = await cameraManager.start(mockVideoElement);
+
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+        video: true,
+        audio: false,
+      });
+      expect(mockVideoElement.srcObject).toBe(mockStream);
+      expect(result).toBe(mockStream);
+      expect(cameraManager.isPlaying).toBe(true);
+    });
+
+    it('should use custom constraints when provided', async () => {
+      const constraints = {video: {width: 1920}, audio: true};
+      await cameraManager.start(mockVideoElement, constraints);
+
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith(
+        constraints,
+      );
+    });
+  });
+
+  describe('stop', () => {
+    it('should stop all tracks and clear video element', async () => {
+      await cameraManager.start(mockVideoElement);
+      cameraManager.stop();
+
+      expect(mockTrack.stop).toHaveBeenCalled();
+      expect(mockVideoElement.srcObject).toBeNull();
+      expect(cameraManager.stream).toBeNull();
+      expect(cameraManager.isPlaying).toBe(false);
+    });
+
+    it('should handle stop when not started', () => {
+      expect(() => cameraManager.stop()).not.toThrow();
+    });
+  });
+
+  describe('pause', () => {
+    it('should pause video element when playing', async () => {
+      await cameraManager.start(mockVideoElement);
+      cameraManager.pause();
+
+      expect(mockVideoElement.pause).toHaveBeenCalled();
+      expect(cameraManager.isPlaying).toBe(false);
+    });
+
+    it('should not pause when already paused', async () => {
+      await cameraManager.start(mockVideoElement);
+      cameraManager.pause();
+      mockVideoElement.pause.mockClear();
+      cameraManager.pause();
+
+      expect(mockVideoElement.pause).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resume', () => {
+    it('should resume video element when paused', async () => {
+      await cameraManager.start(mockVideoElement);
+      cameraManager.pause();
+      cameraManager.resume();
+
+      expect(mockVideoElement.play).toHaveBeenCalled();
+      expect(cameraManager.isPlaying).toBe(true);
+    });
+
+    it('should not resume when already playing', async () => {
+      await cameraManager.start(mockVideoElement);
+      cameraManager.resume();
+
+      expect(mockVideoElement.play).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getStream', () => {
+    it('should return null when not started', () => {
+      expect(cameraManager.getStream()).toBeNull();
+    });
+
+    it('should return stream when started', async () => {
+      await cameraManager.start(mockVideoElement);
+      expect(cameraManager.getStream()).toBe(mockStream);
+    });
+  });
+
+  describe('getVideoSettings', () => {
+    it('should return null when no stream', () => {
+      expect(cameraManager.getVideoSettings()).toBeNull();
+    });
+
+    it('should return video settings when stream exists', async () => {
+      await cameraManager.start(mockVideoElement);
+      const settings = cameraManager.getVideoSettings();
+
+      expect(settings).toEqual({
+        width: 1280,
+        height: 720,
+        frameRate: 30,
+      });
+    });
+
+    it('should return null when no video tracks', async () => {
+      mockStream.getVideoTracks = vi.fn(() => []);
+      await cameraManager.start(mockVideoElement);
+
+      expect(cameraManager.getVideoSettings()).toBeNull();
+    });
+  });
+});

--- a/client/tests/stats.test.js
+++ b/client/tests/stats.test.js
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright 2026 iwatake2222
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {StatsManager} from '../src/stats.js';
+
+describe('StatsManager', () => {
+  let statsManager;
+  let mockElements;
+
+  beforeEach(() => {
+    mockElements = {
+      fps: {textContent: ''},
+      resolution: {textContent: ''},
+      rtt: {textContent: ''},
+      bitrate: {textContent: ''},
+    };
+    statsManager = new StatsManager(mockElements);
+  });
+
+  afterEach(() => {
+    statsManager.stopCollection();
+  });
+
+  describe('constructor', () => {
+    it('should initialize with elements', () => {
+      expect(statsManager.elements).toBe(mockElements);
+      expect(statsManager.intervalId).toBeNull();
+      expect(statsManager.lastBytes).toBe(0);
+      expect(statsManager.lastTimestamp).toBe(0);
+    });
+  });
+
+  describe('update', () => {
+    it('should update fps display', () => {
+      statsManager.update({fps: 29.97});
+      expect(mockElements.fps.textContent).toBe('30.0');
+    });
+
+    it('should update resolution display', () => {
+      statsManager.update({width: 1920, height: 1080});
+      expect(mockElements.resolution.textContent).toBe('1920x1080');
+    });
+
+    it('should update rtt display', () => {
+      statsManager.update({rtt: 15.5});
+      expect(mockElements.rtt.textContent).toBe('15.5');
+    });
+
+    it('should update bitrate display', () => {
+      statsManager.update({bitrate: 2500.123});
+      expect(mockElements.bitrate.textContent).toBe('2500.1');
+    });
+
+    it('should handle partial updates', () => {
+      statsManager.update({fps: 30});
+      expect(mockElements.fps.textContent).toBe('30.0');
+      expect(mockElements.resolution.textContent).toBe('');
+    });
+
+    it('should handle missing elements gracefully', () => {
+      const partialManager = new StatsManager({fps: null, resolution: null});
+      expect(() => partialManager.update({fps: 30})).not.toThrow();
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset all displays to default', () => {
+      statsManager.update({fps: 30, width: 1920, height: 1080, rtt: 10,
+        bitrate: 2000});
+      statsManager.reset();
+
+      expect(mockElements.fps.textContent).toBe('--');
+      expect(mockElements.resolution.textContent).toBe('--');
+      expect(mockElements.rtt.textContent).toBe('--');
+      expect(mockElements.bitrate.textContent).toBe('--');
+    });
+
+    it('should reset internal state', () => {
+      statsManager.lastBytes = 1000;
+      statsManager.lastTimestamp = 5000;
+      statsManager.reset();
+
+      expect(statsManager.lastBytes).toBe(0);
+      expect(statsManager.lastTimestamp).toBe(0);
+    });
+  });
+
+  describe('startLocalStatsCollection', () => {
+    it('should start periodic stats collection', () => {
+      vi.useFakeTimers();
+
+      const mockCameraManager = {
+        getVideoSettings: vi.fn(() => ({
+          width: 1280,
+          height: 720,
+          frameRate: 30,
+        })),
+      };
+
+      statsManager.startLocalStatsCollection(mockCameraManager, 100);
+
+      expect(statsManager.intervalId).not.toBeNull();
+
+      vi.advanceTimersByTime(100);
+      expect(mockCameraManager.getVideoSettings).toHaveBeenCalled();
+      expect(mockElements.fps.textContent).toBe('30.0');
+      expect(mockElements.resolution.textContent).toBe('1280x720');
+
+      vi.useRealTimers();
+    });
+
+    it('should stop previous collection before starting new one', () => {
+      vi.useFakeTimers();
+
+      const mockCameraManager = {
+        getVideoSettings: vi.fn(() => ({width: 640, height: 480,
+          frameRate: 15})),
+      };
+
+      statsManager.startLocalStatsCollection(mockCameraManager, 100);
+      const firstIntervalId = statsManager.intervalId;
+
+      statsManager.startLocalStatsCollection(mockCameraManager, 200);
+      expect(statsManager.intervalId).not.toBe(firstIntervalId);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('stopCollection', () => {
+    it('should stop interval when running', () => {
+      vi.useFakeTimers();
+
+      const mockCameraManager = {
+        getVideoSettings: vi.fn(() => ({width: 640, height: 480,
+          frameRate: 15})),
+      };
+
+      statsManager.startLocalStatsCollection(mockCameraManager);
+      statsManager.stopCollection();
+
+      expect(statsManager.intervalId).toBeNull();
+
+      vi.useRealTimers();
+    });
+
+    it('should handle stop when not running', () => {
+      expect(() => statsManager.stopCollection()).not.toThrow();
+    });
+  });
+
+  describe('calculateBitrate', () => {
+    it('should return 0 on first call', () => {
+      const result = statsManager.calculateBitrate(1000, 1000);
+      expect(result).toBe(0);
+    });
+
+    it('should calculate bitrate correctly', () => {
+      statsManager.calculateBitrate(0, 1000);
+      const result = statsManager.calculateBitrate(125000, 2000);
+      expect(result).toBe(1000);
+    });
+
+    it('should return 0 when time diff is zero', () => {
+      statsManager.calculateBitrate(0, 1000);
+      const result = statsManager.calculateBitrate(1000, 1000);
+      expect(result).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add camera capture module with resolution selection (Full HD, HD, VGA, QVGA)
- Implement collapsible video panels that pause playback when hidden
- Display statistics (frame rate, resolution, RTT, bitrate)
- Add UI with server URL input and connect/disconnect buttons

Closes #10

## Test plan
- [ ] Open client in browser via local server
- [ ] Select resolution from dropdown
- [ ] Click Connect and verify camera permission prompt appears
- [ ] Verify local camera video displays correctly
- [ ] Toggle video panel and verify playback pauses/resumes
- [ ] Click Disconnect and verify camera stops
- [ ] Run `npm test` - all 31 tests pass
- [ ] Run `npx eslint src/ tests/` - no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)