### PR TITLE
feat(client): add 10-second rolling average to statistics

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -98,16 +98,16 @@ limitations under the License.
 
     <!-- Statistics -->
     <div class="card mb-3">
-      <div class="card-header">Statistics</div>
+      <div class="card-header">Statistics (current / 10s avg)</div>
       <div class="card-body stats-display">
         <div class="row">
           <div class="col-md-6">
-            <p class="mb-1">Frame Rate: <span id="statsFps">--</span> fps</p>
+            <p class="mb-1">Frame Rate: <span id="statsFps">-- / --</span> fps</p>
             <p class="mb-1">Resolution: <span id="statsResolution">--</span></p>
           </div>
           <div class="col-md-6">
-            <p class="mb-1">Processing Time: <span id="statsProcessingTime">--</span> ms</p>
-            <p class="mb-1">Latency (RTT): <span id="statsLatency">--</span> ms</p>
+            <p class="mb-1">Processing Time: <span id="statsProcessingTime">-- / --</span> ms</p>
+            <p class="mb-1">Latency (RTT): <span id="statsLatency">-- / --</span> ms</p>
           </div>
         </div>
       </div>

--- a/client/src/stats.js
+++ b/client/src/stats.js
@@ -20,6 +20,12 @@
  */
 
 /**
+ * Duration in milliseconds for calculating rolling average.
+ * @const {number}
+ */
+const AVERAGE_WINDOW_MS = 10000;
+
+/**
  * Statistics manager class for displaying video/connection stats.
  */
 export class StatsManager {
@@ -35,6 +41,57 @@ export class StatsManager {
     this.elements = elements;
     /** @type {number|null} */
     this.intervalId = null;
+    /** @type {Array<{timestamp: number, value: number}>} */
+    this.fpsHistory = [];
+    /** @type {Array<{timestamp: number, value: number}>} */
+    this.processingTimeHistory = [];
+    /** @type {Array<{timestamp: number, value: number}>} */
+    this.latencyHistory = [];
+  }
+
+  /**
+   * Adds a value to history and removes entries older than the window.
+   * @param {Array<{timestamp: number, value: number}>} history - History array.
+   * @param {number} value - Value to add.
+   * @private
+   */
+  addToHistory(history, value) {
+    const now = Date.now();
+    history.push({timestamp: now, value});
+    const cutoff = now - AVERAGE_WINDOW_MS;
+    while (history.length > 0 && history[0].timestamp < cutoff) {
+      history.shift();
+    }
+  }
+
+  /**
+   * Calculates the average of values in history.
+   * @param {Array<{timestamp: number, value: number}>} history - History array.
+   * @return {number|null} Average value or null if no data.
+   * @private
+   */
+  calculateAverage(history) {
+    if (history.length === 0) {
+      return null;
+    }
+    const sum = history.reduce((acc, entry) => acc + entry.value, 0);
+    return sum / history.length;
+  }
+
+  /**
+   * Formats a value with its average for display.
+   * @param {number} current - Current value.
+   * @param {number|null} average - Average value or null.
+   * @param {number} decimals - Number of decimal places.
+   * @return {string} Formatted string like "30.2 / 30.1".
+   * @private
+   */
+  formatWithAverage(current, average, decimals) {
+    const currentStr = current.toFixed(decimals);
+    if (average === null) {
+      return `${currentStr} / --`;
+    }
+    return `${currentStr} / ${average.toFixed(decimals)}`;
   }
 
   /**
@@ -48,18 +105,25 @@ export class StatsManager {
    */
   update(stats) {
     if (stats.fps !== undefined && this.elements.fps) {
-      this.elements.fps.textContent = stats.fps.toFixed(1);
+      this.addToHistory(this.fpsHistory, stats.fps);
+      const avg = this.calculateAverage(this.fpsHistory);
+      this.elements.fps.textContent = this.formatWithAverage(stats.fps, avg, 1);
     }
     if (stats.width !== undefined && stats.height !== undefined &&
         this.elements.resolution) {
       this.elements.resolution.textContent = `${stats.width}x${stats.height}`;
     }
     if (stats.processingTime !== undefined && this.elements.processingTime) {
+      this.addToHistory(this.processingTimeHistory, stats.processingTime);
+      const avg = this.calculateAverage(this.processingTimeHistory);
       this.elements.processingTime.textContent =
-        stats.processingTime.toFixed(1);
+        this.formatWithAverage(stats.processingTime, avg, 1);
     }
     if (stats.latency !== undefined && this.elements.latency) {
-      this.elements.latency.textContent = stats.latency.toFixed(0);
+      this.addToHistory(this.latencyHistory, stats.latency);
+      const avg = this.calculateAverage(this.latencyHistory);
+      this.elements.latency.textContent =
+        this.formatWithAverage(stats.latency, avg, 0);
     }
   }
 
@@ -68,17 +132,20 @@ export class StatsManager {
    */
   reset() {
     if (this.elements.fps) {
-      this.elements.fps.textContent = '--';
+      this.elements.fps.textContent = '-- / --';
     }
     if (this.elements.resolution) {
       this.elements.resolution.textContent = '--';
     }
     if (this.elements.processingTime) {
-      this.elements.processingTime.textContent = '--';
+      this.elements.processingTime.textContent = '-- / --';
     }
     if (this.elements.latency) {
-      this.elements.latency.textContent = '--';
+      this.elements.latency.textContent = '-- / --';
     }
+    this.fpsHistory = [];
+    this.processingTimeHistory = [];
+    this.latencyHistory = [];
   }
 
   /**

--- a/client/tests/stats.test.js
+++ b/client/tests/stats.test.js
@@ -41,12 +41,18 @@ describe('StatsManager', () => {
       expect(statsManager.elements).toBe(mockElements);
       expect(statsManager.intervalId).toBeNull();
     });
+
+    it('should initialize with empty history arrays', () => {
+      expect(statsManager.fpsHistory).toEqual([]);
+      expect(statsManager.processingTimeHistory).toEqual([]);
+      expect(statsManager.latencyHistory).toEqual([]);
+    });
   });
 
   describe('update', () => {
-    it('should update fps display', () => {
+    it('should update fps display with current and average', () => {
       statsManager.update({fps: 29.97});
-      expect(mockElements.fps.textContent).toBe('30.0');
+      expect(mockElements.fps.textContent).toBe('30.0 / 30.0');
     });
 
     it('should update resolution display', () => {
@@ -54,25 +60,32 @@ describe('StatsManager', () => {
       expect(mockElements.resolution.textContent).toBe('1920x1080');
     });
 
-    it('should update processing time display', () => {
+    it('should update processing time display with current and average', () => {
       statsManager.update({processingTime: 15.5});
-      expect(mockElements.processingTime.textContent).toBe('15.5');
+      expect(mockElements.processingTime.textContent).toBe('15.5 / 15.5');
     });
 
-    it('should update latency display', () => {
+    it('should update latency display with current and average', () => {
       statsManager.update({latency: 42.7});
-      expect(mockElements.latency.textContent).toBe('43');
+      expect(mockElements.latency.textContent).toBe('43 / 43');
     });
 
     it('should handle partial updates', () => {
       statsManager.update({fps: 30});
-      expect(mockElements.fps.textContent).toBe('30.0');
+      expect(mockElements.fps.textContent).toBe('30.0 / 30.0');
       expect(mockElements.resolution.textContent).toBe('');
     });
 
     it('should handle missing elements gracefully', () => {
       const partialManager = new StatsManager({fps: null, resolution: null});
       expect(() => partialManager.update({fps: 30})).not.toThrow();
+    });
+
+    it('should calculate rolling average for multiple updates', () => {
+      statsManager.update({fps: 30});
+      statsManager.update({fps: 32});
+      statsManager.update({fps: 28});
+      expect(mockElements.fps.textContent).toBe('28.0 / 30.0');
     });
   });
 
@@ -82,10 +95,19 @@ describe('StatsManager', () => {
         processingTime: 10, latency: 50});
       statsManager.reset();
 
-      expect(mockElements.fps.textContent).toBe('--');
+      expect(mockElements.fps.textContent).toBe('-- / --');
       expect(mockElements.resolution.textContent).toBe('--');
-      expect(mockElements.processingTime.textContent).toBe('--');
-      expect(mockElements.latency.textContent).toBe('--');
+      expect(mockElements.processingTime.textContent).toBe('-- / --');
+      expect(mockElements.latency.textContent).toBe('-- / --');
+    });
+
+    it('should clear history arrays', () => {
+      statsManager.update({fps: 30, processingTime: 10, latency: 50});
+      statsManager.reset();
+
+      expect(statsManager.fpsHistory).toEqual([]);
+      expect(statsManager.processingTimeHistory).toEqual([]);
+      expect(statsManager.latencyHistory).toEqual([]);
     });
   });
 
@@ -107,7 +129,7 @@ describe('StatsManager', () => {
 
       vi.advanceTimersByTime(100);
       expect(mockCameraManager.getVideoSettings).toHaveBeenCalled();
-      expect(mockElements.fps.textContent).toBe('30.0');
+      expect(mockElements.fps.textContent).toBe('30.0 / 30.0');
       expect(mockElements.resolution.textContent).toBe('1280x720');
 
       vi.useRealTimers();


### PR DESCRIPTION
## Summary
- Add 10-second rolling average display to statistics
- Display format: `current / average` (e.g., `30.2 / 30.1`)
- Track history for fps, processingTime, and latency
- Clear history on disconnect/reset

## Test plan
- [x] All tests pass (52 tests)
- [x] ESLint passes
- [x] Verify statistics show current and average values
- [x] Verify average updates over 10 seconds

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)