### PR TITLE
chore: add deny rule for direct push to main branch

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,9 @@
     "deny": [
       "Bash(git push --force:*)",
       "Bash(git reset --hard:*)",
-      "Bash(rm -rf:*)"
+      "Bash(rm -rf:*)",
+      "Bash(git push origin main:*)",
+      "Bash(git push origin main)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- mainブランチへの直接pushを禁止するdenyルールを追加
- `git push origin main`コマンドをブロック

## Test plan
- [ ] Claude Codeで`git push origin main`実行時にブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)