### PR TITLE
feat: add pre-commit skill for branch status check

### DIFF
--- a/.claude/skills/pre-commit/SKILL.md
+++ b/.claude/skills/pre-commit/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: pre-commit
+description: Check branch status before commit. Ensures work is not done on stale/merged branches.
+user-invocable: true
+allowed-tools: Bash, AskUserQuestion
+---
+
+コミット前にブランチ状態を確認し、適切なブランチで作業していることを保証する。
+
+## 手順
+
+1. 現在のブランチ名を取得
+2. mainブランチの場合:
+   - エラー: mainへの直接コミットは禁止
+   - `branch` skillを使って新しいブランチを作成するよう指示
+3. 機能ブランチの場合:
+   - `gh pr list --head <branch-name> --state merged` でマージ済みPRがあるか確認
+   - **マージ済みの場合**:
+     - mainを最新にする (`git checkout main && git pull origin main`)
+     - `branch` skillを使って新しいブランチを作成
+   - **マージされていない場合**:
+     - AskUserQuestionでユーザーに確認:
+       - 選択肢1: 現在のブランチで作業を続ける
+       - 選択肢2: mainを更新して新しいブランチを作成
+     - ユーザーの選択に従って作業を継続

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ client/   # HTML/JS frontend (src/, tests/)
 |-----------|-------|------|
 | ブランチ作成時 | `branch` | 命名規則に従ったブランチ作成 |
 | コード変更後 | `test` | 全テスト実行 |
+| コミット前 | `pre-commit` | ブランチ状態確認（マージ済みブランチでの作業防止） |
 | コミット前 | `lint` | 静的解析（flake8, pylint, ESLint） |
 | コミット前 | `typecheck` | 型チェック（mypy） |
 | PR作成前 | `review` | 変更内容のレビュー（300行制限確認含む） |
@@ -35,11 +36,12 @@ client/   # HTML/JS frontend (src/, tests/)
 1. `branch` → ブランチ作成
 2. コード実装
 3. `test` → テスト実行
-4. `lint` → スタイルチェック
-5. `typecheck` → 型チェック
-6. コミット
-7. `review` → 変更レビュー
-8. `pr` → PR作成
+4. `pre-commit` → ブランチ状態確認
+5. `lint` → スタイルチェック
+6. `typecheck` → 型チェック
+7. コミット
+8. `review` → 変更レビュー
+9. `pr` → PR作成
 
 ## License
 - Apache 2.0 (Copyright 2026 iwatake2222)


### PR DESCRIPTION
## Summary
- マージ済みブランチでの作業を防止する`pre-commit` skillを追加
- コミット前にブランチ状態を確認し、適切なブランチで作業していることを保証
- CLAUDE.mdのワークフローに`pre-commit`ステップを追加

## Test plan
- [ ] マージ済みブランチでコミットしようとした時、mainから新しいブランチを作成するよう誘導されることを確認
- [ ] 未マージのブランチでは、続行するか新しいブランチを作るか選択肢が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)