### PR TITLE
chore(aws): parameterize CloudFormation template for flexible deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,12 @@ python -m src.main --host 0.0.0.0 --port 8080 --cert cert.pem --key key.pem
 cd aws
 
 Region=ap-northeast-1
-AvailabilityZone=ap-northeast-1a
+AvailabilityZone=ap-northeast-1d
+ImageId=ami-0e7d0c8815f409923  # Deep Learning OSS Nvidia Driver AMI GPU PyTorch 2.9 (Ubuntu 24.04)
+InstanceType=g5.4xlarge
+RootVolumeSize=256
 
-SystemName=webrtc-ec2-public-alb
+SystemName=webrtc-alpamayo
 TemplateFileName=./ec2_public_alb.yaml
 
 aws cloudformation deploy \
@@ -128,7 +131,10 @@ aws cloudformation deploy \
 --capabilities CAPABILITY_NAMED_IAM \
 --parameter-overrides \
 SystemName="${SystemName}" \
-AvailabilityZone="${AvailabilityZone}"
+AvailabilityZone="${AvailabilityZone}" \
+ImageId="${ImageId}" \
+InstanceType="${InstanceType}" \
+RootVolumeSize="${RootVolumeSize}"
 ```
 
 ### SSH Configuration
@@ -148,11 +154,13 @@ Host i-* mi-*
 Host webrtc-ec2-server
     HostName i-00000000000000000
     User ubuntu
+    # User ec2-user
     ProxyCommand sh -c "aws ec2-instance-connect send-ssh-public-key --instance-id %h --instance-os-user %r --ssh-public-key 'file://~/.ssh/id_rsa.pub' && aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
 ```
 
 ```bash
 ssh ubuntu@i-00000000000000000
+ssh ec2-user@i-00000000000000000
 # or
 ssh webrtc-ec2-server
 ```

--- a/aws/ec2_public_alb.yaml
+++ b/aws/ec2_public_alb.yaml
@@ -9,6 +9,18 @@ Parameters:
   AvailabilityZone:
     Description: Availability Zone
     Type: AWS::EC2::AvailabilityZone::Name
+  ImageId:
+    Type: AWS::EC2::Image::Id
+    Description: AMI ID # e.g. ami-0f65fc8c24ec8d2a1  (Ubuntu Server 24.04)
+  InstanceType:
+    Type: String
+    Default: t3.medium
+    Description: EC2 instance type
+  RootVolumeSize:
+    Type: Number
+    Default: 128
+    MinValue: 20
+    Description: Root EBS volume size (GiB)
 
 Resources:
   #-----------------------------------------------------------------------------
@@ -80,21 +92,21 @@ Resources:
       GroupDescription: 'Security Group for an EC2 server'
       VpcId: !Ref VPC
       SecurityGroupIngress:
-        # aiohttp
-        - IpProtocol: tcp
-          FromPort: 5000
-          ToPort: 5000
-          CidrIp: 0.0.0.0/0
+        # # aiohttp
+        # - IpProtocol: tcp
+        #   FromPort: 5000
+        #   ToPort: 5000
+        #   CidrIp: 0.0.0.0/0
         # aiohttp
         - IpProtocol: tcp
           FromPort: 8080
           ToPort: 8080
           CidrIp: 0.0.0.0/0
-        # WebRTC
-        - IpProtocol: udp
-          FromPort: 10000
-          ToPort: 20000
-          CidrIp: 0.0.0.0/0
+        # # WebRTC
+        # - IpProtocol: udp
+        #   FromPort: 10000
+        #   ToPort: 20000
+        #   CidrIp: 0.0.0.0/0
       Tags:
         - Key: Name
           Value: !Sub ${SystemName}-ec2-sg
@@ -102,13 +114,13 @@ Resources:
   EC2Instance:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-0f65fc8c24ec8d2a1  # Ubuntu Server 24.04
-      InstanceType: t3.medium
+      ImageId: !Ref ImageId
+      InstanceType: !Ref InstanceType
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeType: gp3
-            VolumeSize: 128
+            VolumeSize: !Ref RootVolumeSize
             Encrypted: true
       IamInstanceProfile:
         !Ref EC2InstanceProfile


### PR DESCRIPTION
## Summary
- Add ImageId, InstanceType, RootVolumeSize as CloudFormation parameters for flexible EC2 configuration
- Update README with Deep Learning AMI (GPU PyTorch) example and g5.4xlarge instance config
- Comment out unused security group rules (port 5000, WebRTC UDP ports) to reduce attack surface
- Add ec2-user SSH option for different AMI compatibility

## Test plan
- [ ] Deploy CloudFormation stack with custom parameters
- [ ] Verify EC2 instance launches with specified AMI and instance type
- [ ] Confirm SSH access works with both ubuntu and ec2-user

🤖 Generated with [Claude Code](https://claude.com/claude-code)