### PR TITLE
feat(client): add camera device selection support

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -45,13 +45,19 @@ limitations under the License.
             <input type="text" class="form-control" id="serverUrl"
                    placeholder="ws://localhost:8080/ws">
           </div>
-          <div class="col-md-3">
+          <div class="col-md-2">
             <label for="resolution" class="form-label">Resolution</label>
             <select class="form-select" id="resolution">
               <option value="1920x1080">1920x1080 (Full HD)</option>
               <option value="1280x720">1280x720 (HD)</option>
               <option value="640x480" selected>640x480 (VGA)</option>
               <option value="320x240">320x240 (QVGA)</option>
+            </select>
+          </div>
+          <div class="col-md-2">
+            <label for="cameraSelect" class="form-label">Camera</label>
+            <select class="form-select" id="cameraSelect">
+              <option value="">Loading...</option>
             </select>
           </div>
           <div class="col-md-3 d-flex gap-2 align-items-end">

--- a/client/src/camera.js
+++ b/client/src/camera.js
@@ -24,6 +24,19 @@
  */
 export class CameraManager {
   /**
+   * Gets a list of available camera devices.
+   * @return {Promise<Array<{deviceId: string, label: string}>>}
+   */
+  static async getCameraDevices() {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices
+      .filter((device) => device.kind === 'videoinput')
+      .map((device, index) => ({
+        deviceId: device.deviceId,
+        label: device.label || `Camera ${index + 1}`,
+      }));
+  }
+  /**
    * Creates a new CameraManager instance.
    */
   constructor() {

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -48,6 +48,9 @@ async function init() {
   const resolutionSelect = /** @type {HTMLSelectElement} */ (
     document.getElementById('resolution')
   );
+  const cameraSelect = /** @type {HTMLSelectElement} */ (
+    document.getElementById('cameraSelect')
+  );
   const connectBtn = /** @type {HTMLButtonElement} */ (
     document.getElementById('connectBtn')
   );
@@ -57,6 +60,8 @@ async function init() {
   const serverResponse = document.getElementById('serverResponse');
 
   serverUrlInput.value = getDefaultServerUrl();
+
+  await populateCameraList(cameraSelect);
 
   statsManager = new StatsManager({
     cameraFps: document.getElementById('statsCameraFps'),
@@ -106,7 +111,10 @@ async function init() {
 
   connectBtn.addEventListener('click', async () => {
     try {
-      const constraints = buildConstraints(resolutionSelect.value);
+      const constraints = buildConstraints(
+        resolutionSelect.value,
+        cameraSelect.value,
+      );
       await cameraManager.start(localVideo, constraints);
       statsManager.startCameraStatsCollection(cameraManager);
 
@@ -121,6 +129,7 @@ async function init() {
       connectBtn.disabled = true;
       disconnectBtn.disabled = false;
       resolutionSelect.disabled = true;
+      cameraSelect.disabled = true;
       serverUrlInput.disabled = true;
 
       if (serverResponse) {
@@ -152,6 +161,7 @@ async function init() {
     connectBtn.disabled = false;
     disconnectBtn.disabled = true;
     resolutionSelect.disabled = false;
+    cameraSelect.disabled = false;
     serverUrlInput.disabled = false;
     if (serverResponse) {
       serverResponse.textContent = 'Disconnected.';
@@ -171,19 +181,52 @@ function getDefaultServerUrl() {
 }
 
 /**
- * Builds media constraints from resolution string.
+ * Builds media constraints from resolution string and optional device ID.
  * @param {string} resolution - Resolution string (e.g., "1280x720").
+ * @param {string} [deviceId] - Optional camera device ID.
  * @return {MediaStreamConstraints} The media constraints object.
  */
-function buildConstraints(resolution) {
+function buildConstraints(resolution, deviceId) {
   const [width, height] = resolution.split('x').map(Number);
+  /** @type {MediaTrackConstraints} */
+  const videoConstraints = {
+    width: {ideal: width},
+    height: {ideal: height},
+  };
+  if (deviceId) {
+    videoConstraints.deviceId = {exact: deviceId};
+  }
   return {
-    video: {
-      width: {ideal: width},
-      height: {ideal: height},
-    },
+    video: videoConstraints,
     audio: false,
   };
+}
+
+/**
+ * Populates the camera selection dropdown.
+ * @param {HTMLSelectElement} selectElement - The select element to populate.
+ */
+async function populateCameraList(selectElement) {
+  try {
+    const cameras = await CameraManager.getCameraDevices();
+    selectElement.innerHTML = '';
+    if (cameras.length === 0) {
+      const option = document.createElement('option');
+      option.value = '';
+      option.textContent = 'No camera found';
+      selectElement.appendChild(option);
+      return;
+    }
+    cameras.forEach((camera) => {
+      const option = document.createElement('option');
+      option.value = camera.deviceId;
+      option.textContent = camera.label;
+      selectElement.appendChild(option);
+    });
+  } catch (error) {
+    console.error('Failed to get camera devices:', error);
+    selectElement.innerHTML = '<option value="">Default</option>';
+  }
 }
 
 /**

--- a/client/tests/camera.test.js
+++ b/client/tests/camera.test.js
@@ -51,6 +51,7 @@ describe('CameraManager', () => {
     global.navigator = {
       mediaDevices: {
         getUserMedia: vi.fn(() => Promise.resolve(mockStream)),
+        enumerateDevices: vi.fn(() => Promise.resolve([])),
       },
     };
   });
@@ -219,6 +220,42 @@ describe('CameraManager', () => {
     it('should return current total frame count', () => {
       cameraManager.totalFrameCount = 42;
       expect(cameraManager.getTotalFrameCount()).toBe(42);
+    });
+  });
+
+  describe('getCameraDevices', () => {
+    it('should return empty array when no cameras', async () => {
+      navigator.mediaDevices.enumerateDevices = vi.fn(() =>
+        Promise.resolve([]),
+      );
+      const devices = await CameraManager.getCameraDevices();
+      expect(devices).toEqual([]);
+    });
+
+    it('should return video input devices only', async () => {
+      navigator.mediaDevices.enumerateDevices = vi.fn(() =>
+        Promise.resolve([
+          {kind: 'videoinput', deviceId: 'cam1', label: 'Front Camera'},
+          {kind: 'audioinput', deviceId: 'mic1', label: 'Microphone'},
+          {kind: 'videoinput', deviceId: 'cam2', label: 'Back Camera'},
+        ]),
+      );
+      const devices = await CameraManager.getCameraDevices();
+      expect(devices).toHaveLength(2);
+      expect(devices[0]).toEqual({deviceId: 'cam1', label: 'Front Camera'});
+      expect(devices[1]).toEqual({deviceId: 'cam2', label: 'Back Camera'});
+    });
+
+    it('should use fallback label when label is empty', async () => {
+      navigator.mediaDevices.enumerateDevices = vi.fn(() =>
+        Promise.resolve([
+          {kind: 'videoinput', deviceId: 'cam1', label: ''},
+          {kind: 'videoinput', deviceId: 'cam2', label: ''},
+        ]),
+      );
+      const devices = await CameraManager.getCameraDevices();
+      expect(devices[0].label).toBe('Camera 1');
+      expect(devices[1].label).toBe('Camera 2');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `CameraManager.getCameraDevices()` static method to enumerate available video input devices
- Add camera selection dropdown to the UI (next to resolution selector)
- Extend `buildConstraints()` to accept and apply selected device ID
- Disable/enable camera selector during connection lifecycle

## Test plan
- [x] Unit tests added for `getCameraDevices()` (3 test cases)
- [ ] Manual test: Connect a device with multiple cameras (e.g., smartphone)
- [ ] Manual test: Verify camera dropdown populates correctly
- [ ] Manual test: Verify selecting different cameras works

🤖 Generated with [Claude Code](https://claude.com/claude-code)