### PR TITLE
fix: revert ICE gathering timeout to 1.5 seconds

### DIFF
--- a/client/src/webrtc.js
+++ b/client/src/webrtc.js
@@ -222,14 +222,14 @@ export class WebRTCClient {
       this.peerConnection.addEventListener(
         'icegatheringstatechange', checkState);
 
-      // Timeout after 15 seconds (extended for unstable network like tethering)
+      // Timeout after 1.5 seconds
       setTimeout(() => {
         if (this.peerConnection) {
           this.peerConnection.removeEventListener(
             'icegatheringstatechange', checkState);
         }
         resolve();
-      }, 15000);
+      }, 1500);
     });
   }
 


### PR DESCRIPTION
## Summary
- Revert ICE gathering timeout from 15 seconds back to 1.5 seconds
- The extended timeout was added for unstable networks (tethering) but is now unnecessary
- Faster connection establishment in stable network environments

## Test plan
- [ ] Verify WebRTC connection establishes correctly
- [ ] Test on stable network connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)